### PR TITLE
Attempt to fix build and add link to docs in readme

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ node_modules/
 
 # Styleguide
 styleguide
+docs
 
 # VSCode
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ install:
 - npm install
 script:
 - npm run validate
-before_deploy:
-- npm install
 deploy:
-  provider: npm
+- provider: npm
   email: gjordan@128technology.com
+  skip_cleanup: true
   api_key:
     secure: p0afqVFxGTW1Ffwuvqg4RBxsL4sLJZGafDEgPximOZWTfJcVNisw5COenfxK8a72+dW+hBawqtlrA3ssmVmjIxm+Qg1pH9W5kfxyH1joEFHAo/JL4U9zVdxGOy+5dC695V70pdV6rCpDg7dc6YNUdXTHds2VVLoOKdlbpJo733Sse0p/9epuj5B++UebcZR+jKCInNalU2KSYqXiIVV/Amxe7s0jAb/YRPifkYfqP3KXNm6vGoKGkXxjtyEII46WJxxbEYmQsahadKXpBlAWDAL85JZdz0sB+q14u3m4QG9f/UqyaJYRP+hdhTBQ+ol0Ijrfg7FyMxBHQNorGp+mxPuSnA7EM22Jawr/Zztxh3YPzil6yfDu/HLUwsc1Y2jRg95sDKftLhAJvDFux2/FQMZ/jC86sV+/byNk0BWFUjHQOh77U410AhD6mLz1KYlRPBEZv2H6xoEFLJATOBkW1+azQWyLj5Kdk3hj2ySIF6YALVIkbW6b01bX485qMuh5HI7E62BmtDuUw70l9C4Rli+fPOsKbkHeGgy4Yu17VVaItGSvg3MmLRSrjYl6TKoBuA46BPF+HCqVaXZbCYRNqmvVbkyxd4UUAijSiIvNHcdxbdP21q9cVdUP8htGTdcMKb0Im5GXn3l5XoFHJfqW8WTw+V3KJVDOwRD3kavtP40=
   on:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 128-UI [![Build Status](https://travis-ci.org/128technology/128-ui.svg?branch=master)](https://travis-ci.org/128technology/128-ui) [![npm version](https://badge.fury.io/js/%40128technology%2Fui.svg)](https://badge.fury.io/js/%40128technology%2Fui)
 
-The 128 Technology, Inc. UI component library.
+The 128 Technology, Inc. UI component library. [Styleguide](https://128technology.github.io/128-ui/).
 
 ## Contributing
 


### PR DESCRIPTION
Adding skip_cleanup to the travis config should allow the build to retain its node_modules folder for when it tries to build the module.