### PR TITLE
Fix regression

### DIFF
--- a/src/components/Autocomplete/Autocomplete.jsx
+++ b/src/components/Autocomplete/Autocomplete.jsx
@@ -160,9 +160,6 @@ class Autocomplete extends React.Component {
           clearable={clearable}
           autosize={true}
           selectComponent={selectComponent}
-          onSelectResetsInput={!creatable}
-          onBlurResetsInput={!creatable}
-          onCloseResetsInput={!creatable}
           {...rest}
         />
         {errorTextComponent}


### PR DESCRIPTION
Autocomplete input field should be cleared out by default.
Caller can override this behavior using the standard react-select properties.