### PR TITLE
Fix scss import issue

### DIFF
--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -1,4 +1,4 @@
-@import "~@mdi/font/scss/materialdesignicons.scss";
+@import "~@mdi/font/css/materialdesignicons.css";
 
 @mixin define-font($filename, $weight, $name) {
   @font-face {


### PR DESCRIPTION
This fixes an issue where sass cannot find the font files that are accompanied by the material design icons npm package.