### PR TITLE
Remove negative margin on matchtext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ui",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "128 Technology UI component library.",
   "main": "dist/index.js",
   "types": "index.d.ts",

--- a/src/components/MatchText/MatchText.scss
+++ b/src/components/MatchText/MatchText.scss
@@ -1,6 +1,4 @@
 .ui-128__match-text--matched {
   background-color: rgba(0, 173, 239, 0.25);
   border-radius: 3px;
-  padding: 0 2px;
-  margin: 0 -2px;
 }


### PR DESCRIPTION
This resolves a problem when a match text component is used within a container that uses overflow hidden and text-overflow ellipsis.