### PR TITLE
Remove white border from around loading indicator

### DIFF
--- a/src/components/Loading/Loading.jsx
+++ b/src/components/Loading/Loading.jsx
@@ -40,7 +40,7 @@ Loading.defaultProps = {
   block: false,
   horizontal: false,
   showLoadingText: true,
-  loadingText: 'Loading...'
+  loadingText: 'Loading'
 };
 
 export default Loading;

--- a/src/components/Loading/Loading.scss
+++ b/src/components/Loading/Loading.scss
@@ -12,7 +12,7 @@
 
   .ui-128__loading__text {
     color: $cyan-128;
-    margin-top: 25px;
+    margin-top: 30px;
     font-family: $rbno31-family;
   }
 }

--- a/src/components/Spinner/Spinner.scss
+++ b/src/components/Spinner/Spinner.scss
@@ -65,7 +65,7 @@ $spinner-icon-margin: 10px;
     background-color: $cyan-128;
     height: $spinner-medium-size;
     width: $spinner-medium-size;
-    border: 3px solid $white;
+    box-shadow: 1px 0 5px 0 rgba(0, 0, 0, 0.2);
     box-sizing: border-box;
   }
 }
@@ -87,7 +87,7 @@ $spinner-icon-margin: 10px;
   .ui-128__spinner-icon-outer {
     height: $spinner-small-size;
     width: $spinner-small-size;
-    border: 2px solid $white;
+    box-shadow: 1px 0 3px 0 rgba(0, 0, 0, 0.2);
   }
 }
 
@@ -120,6 +120,6 @@ $spinner-icon-margin: 10px;
   .ui-128__spinner-icon-outer {
     height: $spinner-huge-size;
     width: $spinner-huge-size;
-    border: 4px solid $white;
+    box-shadow: 1px 0 10px 0 rgba(0, 0, 0, 0.2);
   }
 }


### PR DESCRIPTION
This updates the look of the loading indicator and spinner to give them a slightly more modern look without the white border around them.