### PR TITLE
Fixed type for splitbutton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "128 Technology UI component library.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -42,7 +42,7 @@ const styles = ({ palette, shape }: Theme) =>
 export interface IProps extends WithStyles<typeof styles> {
   variant?: 'contained' | 'raised' | 'text';
   color?: ButtonProps['color'];
-  defaultOnClick?: () => void;
+  defaultOnClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   dropdownIconClassName?: string;
   disabled?: boolean;
   dropdownDisabled?: boolean;


### PR DESCRIPTION
I'm not sure if we need this since we were possibly going to use the mui implementation of the SplitButton later on, but currently the type is incorrect and causing issue in implementation.

EDIT: I would maybe hold off on merging this, it looks like Autocomplete has a type issue as well