### PR TITLE
Fix styling on autocomplete placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ui",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "128 Technology UI component library.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -77,6 +77,7 @@ const styles = ({ spacing, palette, transitions }: Theme) =>
       boxSizing: 'border-box'
     },
     placeholder: {
+      lineHeight: 'inherit',
       userSelect: 'none'
     },
     inputUnderline: {
@@ -102,6 +103,8 @@ const styles = ({ spacing, palette, transitions }: Theme) =>
       }
     },
     dropdownChevron: {
+      display: 'flex',
+      alignItems: 'center',
       height: 19,
       transition: transitions.create(['transform'], {
         easing: transitions.easing.easeInOut,
@@ -113,7 +116,7 @@ const styles = ({ spacing, palette, transitions }: Theme) =>
     }
   });
 
-function DropdownIndicator<OptionType>({ selectProps, isFocused }: IndicatorProps<OptionType>) {
+function DropdownIndicator<OptionType>({ selectProps, isFocused, ...rest }: IndicatorProps<OptionType>) {
   return (
     <Icon
       fontSize="small"


### PR DESCRIPTION
The placeholder on the autocomplete was using a larger line height attribute that caused it to make the outlined selects larger than outlined inputs from material-ui.