### PR TITLE
Updated sort function.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ui",
-  "version": "0.8.14",
+  "version": "0.8.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ui",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "128 Technology UI component library.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/EnhancedTable/EnhancedTable.tsx
+++ b/src/components/EnhancedTable/EnhancedTable.tsx
@@ -13,7 +13,14 @@ import naturalSort = require('javascript-natural-sort');
 import Loading, { LoadingProps } from '../Loading';
 
 export interface IProps<TRow> extends Omit<IMuiVirtualizedTableProps<TRow>, 'width' | 'columns'> {
-  columns: Array<IMuiVirtualizedTableColumn<TRow>>;
+  columns: Array<
+    IMuiVirtualizedTableColumn<TRow> & {
+      customSorter?: (sortParams: {
+        orderBy: keyof TRow;
+        orderDirection?: 'asc' | 'desc';
+      }) => (a: TRow, b: TRow) => number;
+    }
+  >;
   defaultOrderBy?: keyof TRow;
   defaultOrderDirection?: 'asc' | 'desc';
   loading?: boolean;
@@ -59,9 +66,7 @@ export function EnhancedTable<TRow>({
       return data;
     }
 
-    const { orderBy, orderDirection } = sortParams;
-
-    return [...data].sort((first, second) => {
+    const defaultSorter = (first: TRow, second: TRow) => {
       const a = _.get(first, orderBy);
       const b = _.get(second, orderBy);
       // Check if value is either {}, [], undefined, null, but NOT 0 or ''.
@@ -77,8 +82,16 @@ export function EnhancedTable<TRow>({
       } else {
         return naturalSort(_.toString(a), _.toString(b));
       }
-    });
-  }, [data, sortParams]);
+    };
+
+    const { orderBy, orderDirection } = sortParams;
+
+    const curColumn = _.find(columns, ['name', orderBy]);
+    const customSorter = curColumn ? curColumn.customSorter : null;
+    const sorter = customSorter ? customSorter(sortParams) : defaultSorter;
+
+    return [...data].sort(sorter);
+  }, [columns, data, sortParams]);
 
   const onHeaderClick = React.useCallback((e: React.MouseEvent<HTMLElement>, props: IHeaderClickProps<TRow>) => {
     setSortParams(s => {

--- a/src/components/EnhancedTable/EnhancedTable.tsx
+++ b/src/components/EnhancedTable/EnhancedTable.tsx
@@ -62,12 +62,13 @@ export function EnhancedTable<TRow>({
     const { orderBy, orderDirection } = sortParams;
 
     return [...data].sort((first, second) => {
-      const a = first[orderBy];
-      const b = second[orderBy];
-      if (_.isNil(a)) {
+      const a = _.get(first, orderBy);
+      const b = _.get(second, orderBy);
+      // Check if value is either {}, [], undefined, null, but NOT 0 or ''.
+      if (_.isNil(a) || (_.isObject(a) && _.isEmpty(a))) {
         return 1;
       }
-      if (_.isNil(b)) {
+      if (_.isNil(b) || (_.isObject(b) && _.isEmpty(b))) {
         return -1;
       }
 

--- a/src/components/EnhancedTable/__tests__/EnhancedTable-test.tsx
+++ b/src/components/EnhancedTable/__tests__/EnhancedTable-test.tsx
@@ -103,4 +103,46 @@ describe('Enhanced Table', () => {
     expect(cells.at(2).text()).to.equal('dog');
     expect(cells.at(3).text()).to.equal('cat');
   });
+
+  it('should sort based on custom sorter function', () => {
+    const data = [
+      {
+        softwareVersion: '4.2.0'
+      },
+      {
+        softwareVersion: '2.2.0'
+      },
+      {
+        softwareVersion: '3.2.0'
+      }
+    ];
+
+    const columns = [
+      {
+        header: 'Version',
+        name: 'softwareVersion',
+        customSorter: ({ orderDirection }: any) => (a: any, b: any) => {
+          const s =
+            parseInt(a.softwareVersion.split('.')[0], 10) > parseInt(b.softwareVersion.split('.')[0], 10) ? 1 : -1;
+          return s ? (orderDirection === 'desc' ? s * -1 : s) : 0;
+        }
+      }
+    ];
+
+    const component = mount(
+      <EnhancedTable
+        defaultOrderDirection={'desc'}
+        defaultOrderBy={'softwareVersion'}
+        data={data}
+        columns={columns}
+        loading={false}
+        height={500}
+        width={500}
+      />
+    );
+    const cells = component.find(TableCell);
+    expect(cells.at(1).text()).to.equal('4.2.0');
+    expect(cells.at(2).text()).to.equal('3.2.0');
+    expect(cells.at(3).text()).to.equal('2.2.0');
+  });
 });


### PR DESCRIPTION
Note: This is not exactly the most robust solution, the best solution would be to alter mui-virtualized-table dep to use a getter using the column.name for the cell contents as well, so that this change behaves as expected across the board. Feel free to mark as needs work and let me know if you would rather that. The issue with that specifically is that we would need some sort of nested key getter function/polyfill in mui-virt-table or to add lodash as a dependency

Nested keys for column.name can now be used so that the sort function is more versatile. However, column.cell must also be defined as a cell getter. This is simply to prevent having to add nested getter functionality inside mui-virtualized-table, either by polyfill or by new dependencies.