### PR TITLE
Time picker: optional prevent passing null dates, optional show error and message, optional confirm/cancel buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ui",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "description": "128 Technology UI component library.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -5,7 +5,7 @@ import * as moment from 'moment';
 import Week, { IProps as WeekProps } from './Week';
 import Dotw from './Dotw';
 
-export type Colors = 'primary' | 'secondary';
+export type Colors = 'primary' | 'secondary' | 'error';
 
 export interface IProps {
   date?: moment.Moment;

--- a/src/components/Picker/Picker.md
+++ b/src/components/Picker/Picker.md
@@ -1,6 +1,10 @@
 Date Time Range Picker:
 
-    <Picker onChange={console.log} />
+    <Picker onChange={console.log} timeErrorMessage="You must select two dates." closeOnBackgroundClick={true} />
+
+Date Time Range Picker With Confirm/Cancel:
+
+    <Picker onChange={console.log} closeOnBackgroundClick={false} />
 
 Date Time Range Picker Secondary:
 

--- a/src/components/Picker/Picker.md
+++ b/src/components/Picker/Picker.md
@@ -1,8 +1,12 @@
 Date Time Range Picker:
 
-    <Picker onChange={console.log} timeErrorMessage="You must select two dates." closeOnBackgroundClick={true} />
+    <Picker onChange={console.log} />
 
-Date Time Range Picker With Confirm/Cancel:
+Date Time Range Picker with Error (will not pass null to popoverOnClose):
+
+    <Picker onChange={console.log} errorOnNullDate={true} timeErrorMessage="You must select two dates." />
+
+Date Time Range Picker with Confirm/Cancel:
 
     <Picker onChange={console.log} closeOnBackgroundClick={false} />
 

--- a/src/components/Picker/Picker.tsx
+++ b/src/components/Picker/Picker.tsx
@@ -17,6 +17,10 @@ import { VIEWS } from './constants';
 import { Button } from '@material-ui/core';
 
 const styles = ({ typography, spacing, palette }: Theme) => ({
+  buttonContainer: {
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
   contentContainer: {
     overflow: 'hidden',
     fontFamily: typography.fontFamily,
@@ -44,6 +48,8 @@ export interface IProps extends WithStyles<typeof styles> {
   timeErrorMessage?: string | Error;
   closeOnBackgroundClick?: boolean;
   errorOnNullDate?: boolean;
+  cancelButtonText?: string;
+  confirmButtonText?: string;
   onSetTimeError?: () => void;
   onChange?: (startDate: moment.Moment | null, endDate: moment.Moment | null) => void;
   popoverOnClose?: (startDate: moment.Moment | null, endDate: moment.Moment | null) => void;
@@ -431,12 +437,12 @@ export class Picker extends React.Component<IProps, IState> {
               />
             )}
             {this.props.closeOnBackgroundClick === false && (
-            <React.Fragment>
-              <Button color="secondary" onClick={this.onCancel}>Cancel</Button>
-              <Button color="primary" onClick={this.onConfirm} disabled={!this.state.startDate || !this.state.endDate}>Confirm</Button>
-              </React.Fragment>
-              )}
-               {this.state.error && this.props.timeErrorMessage && <div className={classes.errorMessage}>{this.props.timeErrorMessage}</div>}
+              <div className={classes.buttonContainer}>
+                <Button color="secondary" onClick={this.onCancel}>{this.props.cancelButtonText || 'Cancel'}</Button>
+                <Button color="primary" onClick={this.onConfirm} disabled={!this.state.startDate || !this.state.endDate}>{this.props.confirmButtonText || 'Confirm'}</Button>
+              </div>
+            )}
+            {this.state.error && this.props.timeErrorMessage && <div className={classes.errorMessage}>{this.props.timeErrorMessage}</div>}
           </Paper>
         </Popover>
       </div>

--- a/src/components/Picker/Picker.tsx
+++ b/src/components/Picker/Picker.tsx
@@ -43,6 +43,7 @@ export interface IProps extends WithStyles<typeof styles> {
   maxDate?: moment.Moment;
   timeErrorMessage?: string | Error;
   closeOnBackgroundClick?: boolean;
+  errorOnNullDate?: boolean;
   onSetTimeError?: () => void;
   onChange?: (startDate: moment.Moment | null, endDate: moment.Moment | null) => void;
   popoverOnClose?: (startDate: moment.Moment | null, endDate: moment.Moment | null) => void;
@@ -227,7 +228,7 @@ export class Picker extends React.Component<IProps, IState> {
   }
 
   handlePopoverOnClose = (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => {
-    const { popoverOnClose, onSetTimeError, closeOnBackgroundClick } = this.props;
+    const { popoverOnClose, onSetTimeError, closeOnBackgroundClick, errorOnNullDate } = this.props;
     const { startDate, endDate } = this.state;
     if (reason === 'backdropClick' && closeOnBackgroundClick === false) {
       return;
@@ -238,7 +239,7 @@ export class Picker extends React.Component<IProps, IState> {
       return;
     }
     
-    if (!startDate || !endDate) {
+    if ((!startDate || !endDate) && errorOnNullDate) {
       if (onSetTimeError) {
         onSetTimeError();
       }


### PR DESCRIPTION
Made it so that the time picker now has an option to not pass null for startDate/endDate. Also can indicate an "error" if the user tries to close the window without selecting a full date range, with a configurable error message. Closing the popover by clicking on the backdrop can also be disabled, and instead must click Confirm or Cancel (buttons which also have configurable text). This also prevents the user from even triggering an error because the user will have to cancel or select a full time range and confirm. This helps prevent bugs and having to handle cases around the 'popoverOnClose' property from sending `null` as a value for either start or end date.